### PR TITLE
feat: Implement pagination for GET APIs

### DIFF
--- a/controllers/bidController.js
+++ b/controllers/bidController.js
@@ -1,9 +1,11 @@
 const BidProduct = require("../modals/bidModal");
+const { paginate } = require('../utils/pagination');
 
-exports.postProductForBid = async (req, res) => {
-  const {
-    name,
-    description,
+exports.postProductForBid = async (req, res, next) => {
+  try {
+    const {
+      name,
+      description,
     image,
     startingPrice,
     bidEndTime,
@@ -21,24 +23,60 @@ exports.postProductForBid = async (req, res) => {
     creator: { userId, username, avatar },
   });
 
-  await product.save();
-  res.status(201).json({ success: true, product });
+    await product.save();
+    res.status(201).json({ success: true, product });
+  } catch (error) {
+    next(error);
+  }
 };
 
-exports.getActiveBidProducts = async (req, res) => {
-  const now = new Date();
-  const products = await BidProduct.find({ bidEndTime: { $gt: now } });
-  res.json(products);
+exports.getActiveBidProducts = async (req, res, next) => {
+  try {
+    const page = parseInt(req.query.page, 10) || 1;
+    const limit = parseInt(req.query.limit, 10) || 10;
+    const now = new Date();
+    const query = BidProduct.find({ bidEndTime: { $gt: now } });
+    const paginatedResults = await paginate(query, page, limit);
+
+    if (!paginatedResults.data || paginatedResults.data.length === 0) {
+      return res.status(404).json({ status: false, message: "No active bid products found" });
+    }
+    res.status(200).json({ status: true, ...paginatedResults });
+  } catch (error) {
+    next(error);
+  }
 };
 
-exports.getUserBidProducts = async (req, res) => {
-  const { userId } = req.params;
-  const products = await BidProduct.find({ "creator.userId": userId });
-  res.json(products);
+exports.getUserBidProducts = async (req, res, next) => {
+  try {
+    const { userId } = req.params;
+    const page = parseInt(req.query.page, 10) || 1;
+    const limit = parseInt(req.query.limit, 10) || 10;
+    const query = BidProduct.find({ "creator.userId": userId });
+    const paginatedResults = await paginate(query, page, limit);
+
+    if (!paginatedResults.data || paginatedResults.data.length === 0) {
+      return res.status(404).json({ status: false, message: "No bid products found for this user" });
+    }
+    res.status(200).json({ status: true, ...paginatedResults });
+  } catch (error) {
+    next(error);
+  }
 };
 
-exports.getUserParticipatedBids = async (req, res) => {
-  const { userId } = req.params;
-  const products = await BidProduct.find({ "bids.userId": userId });
-  res.json(products);
+exports.getUserParticipatedBids = async (req, res, next) => {
+  try {
+    const { userId } = req.params;
+    const page = parseInt(req.query.page, 10) || 1;
+    const limit = parseInt(req.query.limit, 10) || 10;
+    const query = BidProduct.find({ "bids.userId": userId });
+    const paginatedResults = await paginate(query, page, limit);
+
+    if (!paginatedResults.data || paginatedResults.data.length === 0) {
+      return res.status(404).json({ status: false, message: "No bids participated in by this user" });
+    }
+    res.status(200).json({ status: true, ...paginatedResults });
+  } catch (error) {
+    next(error);
+  }
 };

--- a/controllers/orderController.js
+++ b/controllers/orderController.js
@@ -1,5 +1,6 @@
 const Orders = require("../modals/order");
 const sendEmail = require("../utils/sendEmail.js");
+const { paginate } = require('../utils/pagination');
 
 module.exports = {
   createOrder: async (req, res, next) => {
@@ -59,6 +60,8 @@ module.exports = {
   findOrdersByEmail: async (req, res, next) => {
     try {
       const { email } = req.query;
+      const page = parseInt(req.query.page, 10) || 1;
+      const limit = parseInt(req.query.limit, 10) || 10;
 
       if (!email) {
         return res.status(400).json({
@@ -67,16 +70,17 @@ module.exports = {
         });
       }
 
-      const orders = await Orders.find({ email });
+      const query = Orders.find({ email });
+      const paginatedResults = await paginate(query, page, limit);
 
-      if (!orders || orders.length === 0) {
+      if (!paginatedResults.data || paginatedResults.data.length === 0) {
         return res.status(404).json({
           status: false,
           message: "No orders found for this email",
         });
       }
 
-      res.status(200).json({ status: true, orders });
+      res.status(200).json({ status: true, ...paginatedResults });
     } catch (error) {
       return next(error);
     }

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -1,4 +1,5 @@
 const Product = require("../modals/product");
+const { paginate } = require('../utils/pagination');
 
 const getProductById = async (id) => {
   return Product.findById(id);
@@ -7,13 +8,17 @@ const getProductById = async (id) => {
 module.exports = {
   getAllProducts: async (req, res, next) => {
     try {
-      const data = await Product.find();
-      if (!data || data.length === 0) {
+      const page = parseInt(req.query.page, 10) || 1;
+      const limit = parseInt(req.query.limit, 10) || 10;
+      const query = Product.find();
+      const paginatedResults = await paginate(query, page, limit);
+
+      if (!paginatedResults.data || paginatedResults.data.length === 0) {
         return res
           .status(404)
           .json({ status: false, message: "No data found" });
       }
-      res.status(200).json({ status: true, products: data });
+      res.status(200).json({ status: true, ...paginatedResults });
     } catch (error) {
       console.error(error);
       return next(error);
@@ -41,6 +46,8 @@ module.exports = {
   searchProductsByName: async (req, res, next) => {
     try {
       const { name } = req.query;
+      const page = parseInt(req.query.page, 10) || 1;
+      const limit = parseInt(req.query.limit, 10) || 10;
 
       if (!name || name.trim() === "") {
         return res
@@ -49,15 +56,16 @@ module.exports = {
       }
 
       const regex = new RegExp(name, "i"); // Case-insensitive search
-      const products = await Product.find({ name: regex });
+      const query = Product.find({ name: regex });
+      const paginatedResults = await paginate(query, page, limit);
 
-      if (!products.length) {
+      if (!paginatedResults.data || paginatedResults.data.length === 0) {
         return res
           .status(404)
           .json({ status: false, message: "No matching products found" });
       }
 
-      res.status(200).json({ status: true, products });
+      res.status(200).json({ status: true, ...paginatedResults });
     } catch (error) {
       console.error(error);
       return next(error);

--- a/controllers/taskController.js
+++ b/controllers/taskController.js
@@ -1,17 +1,21 @@
 const task = require("../modals/task");
+const { paginate } = require('../utils/pagination');
 
 module.exports = {
   getUserTasks: async (req, res, next) => {
     try {
-      const tasks = await task.find();
+      const page = parseInt(req.query.page, 10) || 1;
+      const limit = parseInt(req.query.limit, 10) || 10;
+      const query = task.find();
+      const paginatedResults = await paginate(query, page, limit);
 
-      if (!tasks || tasks.length === 0) {
+      if (!paginatedResults.data || paginatedResults.data.length === 0) {
         return res
           .status(404)
           .json({ status: false, message: "No tasks found" });
       }
 
-      res.status(200).json({ status: true, tasks });
+      res.status(200).json({ status: true, ...paginatedResults });
     } catch (error) {
       console.error("Failed to fetch tasks:", error);
       return next(error);

--- a/utils/pagination.js
+++ b/utils/pagination.js
@@ -1,0 +1,36 @@
+/**
+ * @param {import('mongoose').Query} query Mongoose query object
+ * @param {number} page Current page number
+ * @param {number} limit Number of items per page
+ * @returns {Promise<Object>} Paginated results
+ */
+async function paginate(query, page, limit) {
+  // Sanitize page and limit inputs
+  const pageNumber = Math.max(1, parseInt(page, 10) || 1);
+  const itemsPerPage = Math.max(1, parseInt(limit, 10) || 10);
+
+  // Calculate skip value
+  const skipValue = (pageNumber - 1) * itemsPerPage;
+
+  // Clone the query for countDocuments to avoid issues with an already executed query
+  const countQuery = query.clone();
+
+  // Execute query with skip and limit
+  const data = await query.skip(skipValue).limit(itemsPerPage).exec();
+
+  // Get total count of documents
+  const totalItems = await countQuery.countDocuments();
+
+  // Calculate total pages
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
+
+  return {
+    data,
+    currentPage: pageNumber,
+    totalPages,
+    totalItems,
+    itemsPerPage,
+  };
+}
+
+module.exports = { paginate };


### PR DESCRIPTION
Added pagination to various GET API endpoints to improve performance and your experience when dealing with large datasets.

Key changes:
- Created a reusable `paginate` utility function in `utils/pagination.js` to handle common pagination logic (calculating skip, limit, total pages, etc.) for Mongoose queries.
- Integrated this `paginate` utility into the following controllers and functions:
    - `productController.js`: - `getAllProducts` - `searchProductsByName`
    - `bidController.js`:
        - `getActiveBidProducts`
        - `getUserBidProducts` - `getUserParticipatedBids`
    - `orderController.js`: - `findOrdersByEmail`
    - `taskController.js`:
        - `getUserTasks`
- Updated relevant API responses to include pagination metadata (currentPage, totalPages, totalItems, itemsPerPage) alongside the data array.
- Ensured that API endpoints now accept `page` and `limit` query parameters.